### PR TITLE
add crypto to app file

### DIFF
--- a/src/pgsql.app.src
+++ b/src/pgsql.app.src
@@ -12,6 +12,6 @@
             pgsql_sup
             ]},
         {registered,    [pgsql_sup, pgsql_connection_sup]},
-        {applications,  [kernel, stdlib]},
+        {applications,  [kernel, stdlib, crypto]},
         {mod,           {pgsql_app, []}}
     ]}.


### PR DESCRIPTION
Crypto is used but not specified in the app file. This means when a release is generated with `relx` the need for cyrpto is not detected and thus not included in the lib dir of the target system.
