### PR TITLE
Adjust return type spec of simple_query/{1,2,3}

### DIFF
--- a/src/pgsql_connection.erl
+++ b/src/pgsql_connection.erl
@@ -269,12 +269,12 @@ param_query(Query, Parameters, QueryOptions, Timeout, Connection) ->
 
 %%--------------------------------------------------------------------
 %% @doc Perform a simple query.
-%% 
--spec simple_query(iodata(), pgsql_connection()) -> result_tuple() | {error, any()}.
+%%
+-spec simple_query(iodata(), pgsql_connection()) -> result_tuple() | [result_tuple()] | {error, any()}.
 simple_query(Query, Connection) ->
     simple_query(Query, [], Connection).
 
--spec simple_query(iodata(), query_options(), pgsql_connection()) -> result_tuple() | {error, any()}.
+-spec simple_query(iodata(), query_options(), pgsql_connection()) -> result_tuple() | [result_tuple()] | {error, any()}.
 simple_query(Query, QueryOptions, Connection) ->
     simple_query(Query, QueryOptions, ?REQUEST_TIMEOUT, Connection).
 
@@ -283,7 +283,7 @@ simple_query(Query, QueryOptions, Connection) ->
 %% will confuse timeout logic and such manual handling of statement_timeout
 %% should not be mixed with calls to simple_query/4.
 %%
--spec simple_query(iodata(), query_options(), timeout(), pgsql_connection()) -> result_tuple() | {error, any()}.
+-spec simple_query(iodata(), query_options(), timeout(), pgsql_connection()) -> result_tuple() | [result_tuple()] | {error, any()}.
 simple_query(Query, QueryOptions, Timeout, {pgsql_connection, ConnectionPid}) ->
     call_and_retry(ConnectionPid, {simple_query, Query, QueryOptions, Timeout}, proplists:get_bool(retry, QueryOptions), adjust_timeout(Timeout)).
 


### PR DESCRIPTION
A simple query that performs multiple actions
result in a list of results. The current spec
definition does not reflect this.

An very artificial example would be:

``` erlang
Sql = [
  "CREATE TABLE table1 (n integer);"
  "CREATE TABLE table2 (n integer);"
  "DROP TABLE table1;"
  "DROP TABLE table2;"
],
pgsql_connection:simple_query(Sql, C)
```

Which returns:

``` erlang
[
  {{drop,table},[]},
  {{drop,table},[]},
  {{create,table},[]},
  {{create,table},[]}
]
```

This does not correspond to the return type of result_tuple(),
but rather [result_tuple()], like is used in batch_query/{3,4,5}
