### PR TITLE
Fix for negative timezones in simple_query calls

### DIFF
--- a/src/pgsql_protocol.erl
+++ b/src/pgsql_protocol.erl
@@ -782,7 +782,7 @@ decode_value_text(?TIMEOID, Value, _OIDMap) ->
     {Hour, Min, Secs};
 decode_value_text(?TIMETZOID, Value, _OIDMap) ->
     {ok, [Hour, Min], SecsStr0} = io_lib:fread("~u:~u:", binary_to_list(Value)),
-    SecsStr = case string:tokens(SecsStr0, "+") of
+    SecsStr = case string:tokens(SecsStr0, "+-") of
         [SecsStr1, _TZ] -> SecsStr1;
         [SecsStr1] -> SecsStr1
     end,
@@ -806,7 +806,7 @@ decode_value_text(?TIMESTAMPOID, Value, _OIDMap) ->
     {{Year, Month, Day}, {Hour, Min, Secs}};
 decode_value_text(?TIMESTAMPTZOID, Value, _OIDMap) ->
     {ok, [Year, Month, Day, Hour, Min], SecsStr0} = io_lib:fread("~u-~u-~u ~u:~u:", binary_to_list(Value)),
-    SecsStr = case string:tokens(SecsStr0, "+") of
+    SecsStr = case string:tokens(SecsStr0, "+-") of
         [SecsStr1, _TZ] -> SecsStr1;
         [SecsStr1] -> SecsStr1
     end,


### PR DESCRIPTION
Hello Paul, 

could you please take a look at the changes I made. They are very simple and I guess are obvious.
They fixed the crashes for the simple_query calls returning the timestamps with the timezone. 
One thing is still needed to clarify. The extended_query call returns the time in UTC if the returned value has a timezone. I think it makes sense. The simple_query though returns the time in local zone, this seems to me inconsistent...
Thank you!

Sincerely,
  Vlad P.