### PR TITLE
Add support for COPY

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ Perform an extended query and fold (resp. map, execute a function on each row). 
     
 Cancel the current running query. This opens a new connection to cancel the query (out-of-band cancelation).
 
+### COPY support ###
+
+```COPY``` is a PostgreSQL-specific command for bulk transfers of table contents. It is less structured and more brittle to user errors.
+
+#### copying from a table ####
+
+```Connection:simple_query("COPY mytable TO STDOUT")``` will return ```{{copy, ListSize},[<<Tab-delimited data>>, ...]}```. ```ListSize``` is the number of elements in the associated list, which often corresponds to the number of rows in the table. The actual contents of the returned data depend on the COPY query (for example, specifying a format).
+
+```extended_query```, ```fold```, ```map```, and ```foreach``` may also be used, but note that Postgres does not permit parameter-binding in COPY queries.
+
 ### ODBC-like API ###
 
 The driver also has an ODBC-like interface, which is deprecated. It is composed of ```sql_query/2,3,4```, ```param_query/3,4,5``` and utility function ```convert_statement/1```

--- a/README.md
+++ b/README.md
@@ -73,6 +73,19 @@ Cancel the current running query. This opens a new connection to cancel the quer
 
 ```extended_query```, ```fold```, ```map```, and ```foreach``` may also be used, but note that Postgres does not permit parameter-binding in COPY queries.
 
+#### copying to a table ####
+
+Begin a copy using `simple_query` (not `extended_query`) to copy from "stdin". Then perform any number of `send_copy_data/2` to transmit data to Postgres' stdin. Finally, `send_copy_end/1` to have Postgres process the data.
+
+```erlang
+{copy_in,_} = Connection:simple_query("COPY people(fn,ln) FROM STDIN"),
+ok = Connection:send_copy_data(<<"Donald\tChamberlin\nRaymond\tBoyce\nMi">>),
+ok = Connection:send_copy_data(<<"chael\tStonebraker\n">>),
+{copy,3} = Connection:send_copy_end()
+```
+
+Using `COPY` is generally the fastest method to bulk-insert data by a large margin.
+
 ### ODBC-like API ###
 
 The driver also has an ODBC-like interface, which is deprecated. It is composed of ```sql_query/2,3,4```, ```param_query/3,4,5``` and utility function ```convert_statement/1```

--- a/src/pgsql_connection.erl
+++ b/src/pgsql_connection.erl
@@ -41,6 +41,9 @@
     foreach/4,
     foreach/5,
     foreach/6,
+	 
+    send_copy_data/2,
+    send_copy_end/1,
     
     % Cancel current query
     cancel/1,
@@ -172,6 +175,8 @@
     |   no_data
         % expect ready_for_query
     |   {result, any()}.
+
+-define(binary_to_integer(Bin), list_to_integer(binary_to_list(Bin))).
 
 %%--------------------------------------------------------------------
 %% @doc Open a connection to a database, throws an error if it failed.
@@ -385,6 +390,20 @@ foreach(Function, Query, Parameters, QueryOptions, Connection) ->
 -spec foreach(fun((tuple()) -> any()), iodata(), [any()], query_options(), timeout(), pgsql_connection()) -> ok | {error, any()}.
 foreach(Function, Query, Parameters, QueryOptions, Timeout, {pgsql_connection, ConnectionPid}) ->
     call_and_retry(ConnectionPid, {foreach, Query, Parameters, Function, QueryOptions, Timeout}, proplists:get_bool(retry, QueryOptions), adjust_timeout(Timeout)).
+
+%%--------------------------------------------------------------------
+%% @doc Send some binary data after starting a COPY
+%%
+-spec send_copy_data(iodata(), pgsql_connection()) -> ok | {error, any()}.
+send_copy_data(Data, {pgsql_connection, ConnectionPid}) ->
+    call_and_retry(ConnectionPid, {send_copy_data, Data}, false, infinity).
+
+%%--------------------------------------------------------------------
+%% @doc Finish a COPY
+%%
+-spec send_copy_end(pgsql_connection()) -> {copy, integer()} | {error, any()}.
+send_copy_end({pgsql_connection, ConnectionPid}) ->
+    call_and_retry(ConnectionPid, {send_copy_end}, false, infinity).
 
 %%--------------------------------------------------------------------
 %% @doc Cancel the current query.
@@ -779,6 +798,9 @@ pgsql_simple_query_loop(Result0, Acc, AsyncT, #state{socket = Socket, subscriber
 	    pgsql_simple_query_loop({copy, Fields, AccData1}, Acc, AsyncT, State0);
 	{ok, #copy_done{}} ->
 	    pgsql_simple_query_loop(Result0, Acc, AsyncT, State0);
+	{ok, #copy_in_response{format = Format}} when Result0 =:= [] ->
+	    Fields = [Format],
+	    return_async({copy_in, Fields}, AsyncT, State0);
         {ok, #command_complete{command_tag = Tag}} ->
             ResultRows = case Result0 of
                 {rows, _Descs, AccRows} -> lists:reverse(AccRows);
@@ -922,7 +944,7 @@ pgsql_extended_query_receive_loop(_LoopState, _Fun, _Acc, _FinalizeFun, _MaxRows
 pgsql_extended_query_receive_loop(LoopState, Fun, Acc0, FinalizeFun, MaxRowsStep, AsyncT, #state{socket = Socket, subscribers = Subscribers} = State0) ->
     case receive_message(Socket, AsyncT, Subscribers) of
         {ok, Message} ->
-            pgsql_extended_query_receive_loop0(Message, LoopState, Fun, Acc0, FinalizeFun, MaxRowsStep, AsyncT, State0);
+	    pgsql_extended_query_receive_loop0(Message, LoopState, Fun, Acc0, FinalizeFun, MaxRowsStep, AsyncT, State0);
         {error, _} = ReceiveError ->
             return_async(ReceiveError, AsyncT, State0)
     end.
@@ -977,7 +999,7 @@ pgsql_extended_query_receive_loop0(#copy_out_response{format = Format}, _LoopSta
     Fields = [Format],
     State1 = oob_update_oid_map_from_fields_if_required(Fields, State0),
     pgsql_extended_query_receive_loop({copy, Fields}, Fun, Acc0, FinalizeFun, MaxRowsStep, AsyncT, State1);
-pgsql_extended_query_receive_loop0(#copy_data{data = Data}, {copy, Fields} = LoopState, Fun, Acc0, FinalizeFun, MaxRowsStep, AsyncT, State0) ->
+pgsql_extended_query_receive_loop0(#copy_data{data = Data}, {copy, _Fields} = LoopState, Fun, Acc0, FinalizeFun, MaxRowsStep, AsyncT, State0) ->
     Acc1 = Fun(Data, Acc0),
     pgsql_extended_query_receive_loop(LoopState, Fun, Acc1, FinalizeFun, MaxRowsStep, AsyncT, State0);
 pgsql_extended_query_receive_loop0(#copy_done{}, LoopState, Fun, Acc0, FinalizeFun, MaxRowsStep, AsyncT, State0) ->
@@ -1002,6 +1024,14 @@ pgsql_extended_query_receive_loop0(#portal_suspended{}, LoopState, Fun, Acc0, Fi
     end;
 pgsql_extended_query_receive_loop0(#ready_for_query{}, {result, Result}, _Fun, _Acc0, _FinalizeFun, _MaxRowsStep, AsyncT, State0) ->
     return_async(Result, AsyncT, State0);
+pgsql_extended_query_receive_loop0(#copy_in_response{}, LoopState, Fun, Acc0, FinalizeFun, MaxRowsStep, AsyncT, #state{socket={SockModule,Sock}}=State0) ->
+    ErrorMessage = <<"Cannot use COPY with extended_query">>,
+    Packet = [pgsql_protocol:encode_copy_fail(ErrorMessage),pgsql_protocol:encode_sync_message()],
+    Res= SockModule:send(Sock, Packet),
+    case Res of
+	ok -> pgsql_extended_query_receive_loop(LoopState, Fun, Acc0, FinalizeFun, MaxRowsStep, AsyncT, State0);
+	{error,_} = SendError -> return_async(SendError, AsyncT, State0)
+    end;
 pgsql_extended_query_receive_loop0(#error_response{fields = Fields}, _LoopState, _Fun, _Acc0, _FinalizeFun, 0, AsyncT, State0) ->
     Error = {error, {pgsql_error, Fields}},
     flush_until_ready_for_query(Error, AsyncT, State0);
@@ -1017,6 +1047,27 @@ pgsql_extended_query_receive_loop0(#ready_for_query{} = Message, _LoopState, _Fu
 pgsql_extended_query_receive_loop0(Message, _LoopState, _Fun, _Acc0, _FinalizeFun, _MaxRowsStep, AsyncT, State0) ->
     Error = {error, {unexpected_message, Message}},
     flush_until_ready_for_query(Error, AsyncT, State0).
+
+pgsql_send_copy_data(Data, From, #state{socket = {SockModule, Sock}} = State0) ->
+    Message = pgsql_protocol:encode_copy_data_message(Data),
+    Result = SockModule:send(Sock, Message),
+    gen_server:reply(From, Result),
+    State0#state{current = undefined}.
+
+pgsql_send_copy_end(From, #state{socket = {SockModule, Sock}} = State0) ->
+    Message = pgsql_protocol:encode_copy_done(),
+    Result0 = SockModule:send(Sock, Message),
+    {Result1, State1} = pgsql_send_copy_end_flush(Result0, State0),
+    gen_server:reply(From, Result1),
+    State1.
+pgsql_send_copy_end_flush(Result0, #state{socket = Socket, subscribers = Subscribers} = State0) ->
+    case receive_message(Socket, sync, Subscribers) of
+	{ok, {command_complete, <<"COPY ",CopyCount/binary>>}} ->
+	    CopyCountNum = ?binary_to_integer(CopyCount),
+	    pgsql_send_copy_end_flush({copy,CopyCountNum}, State0);
+	{ok, {ready_for_query, _}} ->
+	    {Result0, State0#state{current = undefined}}
+    end.
 
 flush_until_ready_for_query(Result, AsyncT, #state{socket = Socket, subscribers = Subscribers} = State0) ->
     case receive_message(Socket, AsyncT, Subscribers) of
@@ -1403,7 +1454,12 @@ do_query0({map, Query, Parameters, Function, QueryOptions, Timeout}, From, #stat
     pgsql_extended_query(Query, Parameters, fun map_fn/2, {Function, []}, fun map_finalize/2, {cursor, MaxRowsStep}, Timeout, From, State0);
 do_query0({foreach, Query, Parameters, Function, QueryOptions, Timeout}, From, #state{} = State0) ->
     MaxRowsStep = proplists:get_value(max_rows_step, QueryOptions, ?DEFAULT_MAX_ROWS_STEP),
-    pgsql_extended_query(Query, Parameters, fun foreach_fn/2, Function, fun foreach_finalize/2, {cursor, MaxRowsStep}, Timeout, From, State0).
+    pgsql_extended_query(Query, Parameters, fun foreach_fn/2, Function, fun foreach_finalize/2, {cursor, MaxRowsStep}, Timeout, From, State0);
+do_query0({send_copy_data, Data}, From, State0) ->
+    pgsql_send_copy_data(Data, From, State0);
+do_query0({send_copy_end}, From, State0) ->
+    pgsql_send_copy_end(From, State0).
+
 
 command_completed(Command, #state{current = Command, pending = []} = State) ->
     set_active_once(State),

--- a/src/pgsql_protocol.erl
+++ b/src/pgsql_protocol.erl
@@ -19,6 +19,9 @@
     encode_sync_message/0,
     encode_flush_message/0,
     encode_cancel_message/2,
+    encode_copy_data_message/1,
+    encode_copy_done/0,
+    encode_copy_fail/1,
     
     decode_message/2,
     decode_row/4,
@@ -70,6 +73,30 @@ encode_password_message(Password) ->
 encode_query_message(Query) ->
     encode_string_message($Q, Query).
 
+%%--------------------------------------------------------------------
+%% @doc Encode a data segment of a COPY operation
+%%
+-spec encode_copy_data_message(iodata()) -> binary().
+encode_copy_data_message(Message) ->
+    StringBin = iolist_to_binary(Message),
+    MessageLen = byte_size(StringBin) + 4,
+    <<$d, MessageLen:32/integer, StringBin/binary>>.
+
+%%--------------------------------------------------------------------
+%% @doc Encode the end of a COPY operation
+%%
+-spec encode_copy_done() -> binary().
+encode_copy_done() ->
+    <<$c, 4:32/integer>>.
+
+%%--------------------------------------------------------------------
+%% @doc Encode the cancellation of a COPY operation with the given
+%%      failure message
+%%
+-spec encode_copy_fail(iodata()) -> binary().
+encode_copy_fail(ErrorMessage) ->
+    encode_string_message($f, ErrorMessage).
+    
 %%--------------------------------------------------------------------
 %% @doc Encode a parse message.
 %%


### PR DESCRIPTION
Adds support for `COPY table TO STDOUT` and `COPY table FROM STDIN` types of queries.

`COPY TO` is pretty simple and is just kind of a completeness thing. `COPY FROM` is very nice for bulk inserts. I only implemented support for it along the `simple_query` path. Besides being easier, I don't think any of the `extended_query` features are available within the context of a COPY.

Also added tests and a section of the README.

Sample usage:
```erlang
{copy_in,_} = Connection:simple_query("COPY people(fn,ln) FROM STDIN"),
ok = Connection:send_copy_data(<<"Donald\tChamberlin\nRaymond\tBoyce\nMi">>),
ok = Connection:send_copy_data(<<"chael\tStonebraker\n">>),
{copy,3} = Connection:send_copy_end()
```

Running some quick tests, a naive COPY is about 16 times faster than a naive INSERT: https://gist.github.com/waisbrot/6dc9c5c1e71fc75cd264

(This closes #22 )
