### PR TITLE
Add `unlisten` to return tuple spec

### DIFF
--- a/src/pgsql_connection.erl
+++ b/src/pgsql_connection.erl
@@ -106,7 +106,7 @@
 -type odbc_result_tuple() :: {updated, n_rows()} | {updated, n_rows(), rows()} | {selected, rows()}.
 
 -type result_tuple() ::
-    {'begin' | commit | 'do' | listen | notify | rollback | set | {declare, cursor} | {lock, table}, []}
+    {'begin' | commit | 'do' | listen | unlisten | notify | rollback | set | {declare, cursor} | {lock, table}, []}
     | {{insert, integer(), integer()}, rows()}
     | {{copy | delete | fetch | move | select | update, integer()}, rows()}
     | {{alter | create | drop, atom()} | {start, transaction}, []}


### PR DESCRIPTION
`{unlisten, []}` is also a valid result of
a pgsql_connection:* call.

See the following example:

```erl
(air@127.0.0.1)1> DbConnectionParams = ...
(air@127.0.0.1)2> Connection = pgsql_connection:open(DbConnectionParams).
{pgsql_connection,<0.230.0>}
(air@127.0.0.1)3> pgsql_connection:simple_query("UNLISTEN *", Connection).
{unlisten,[]}
(air@127.0.0.1)4> pgsql_connection:simple_query("LISTEN foo", Connection).
{listen,[]}
(air@127.0.0.1)5> pgsql_connection:simple_query("UNLISTEN foo", Connection).
{unlisten,[]}
(air@127.0.0.1)6> pgsql_connection:simple_query("LISTEN foo", Connection).
{listen,[]}
(air@127.0.0.1)7> pgsql_connection:simple_query("UNLISTEN *", Connection).
{unlisten,[]}
```