### PR TITLE
Allow SSL options

### DIFF
--- a/test/pgsql_connection_test.erl
+++ b/test/pgsql_connection_test.erl
@@ -1184,7 +1184,7 @@ postgression_ssl_test_() ->
                     },
                     {"SSL Connection test",
                     ?_test(begin
-                        Conn = pgsql_connection:open(Host, Database, User, Password, [{port, Port}, {ssl, true}]),
+                        Conn = pgsql_connection:open(Host, Database, User, Password, [{port, Port}, {ssl, true}, {ssl_options, [{verify, verify_none}]}]),
                         ?assertEqual({show, [{<<"on">>}]}, pgsql_connection:simple_query("show ssl", Conn)),
                         pgsql_connection:close(Conn)
                     end)


### PR DESCRIPTION
Add new option `ssl_options` to `open_options` which allows to set custom `ssl:ssl_option`s.  Allows users to improve the security  of their connections.