### PR TITLE
json/jsonb support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+_build
+.rebar3
 .eunit
 ebin
 .DS_Store

--- a/src/pgsql_internal.hrl
+++ b/src/pgsql_internal.hrl
@@ -1,9 +1,10 @@
-
 % Backend messages
 -type pgsql_oid() :: pos_integer().
 -type pgsql_procid() :: integer().
 -type pgsql_format() :: text | binary.
 -type pgsql_oid_map() :: gb_trees:tree(pgsql_oid(), atom()).
+
+-define(JSONB_VERSION_1, 1).
 
 % from pg_type.h
 -define(BOOLOID, 16).
@@ -22,6 +23,7 @@
 -define(CIDOID, 29).
 -define(OIDVECTOROID, 30).
 -define(JSONOID, 114).
+-define(JSONBOID, 3802).
 -define(XMLOID, 142).
 -define(PGNODETREEOID, 194).
 -define(POINTOID, 600).
@@ -132,6 +134,7 @@
 {?CIDOID, cid},
 {?OIDVECTOROID, oidvector},
 {?JSONOID, json},
+{?JSONBOID, jsonb},
 {?XMLOID, xml},
 {?PGNODETREEOID, pgnodetree},
 {?POINTOID, point},


### PR DESCRIPTION
This patch adds to the protocol support for sending `jsonb` data. But currently it requires the user to pass an already encoded json binary string and returns an encoded json binary string in results which have to be decoded by the user.

Do you have any thoughts on how (assuming you don't want to just keep it as is?) you'd want json encoding/decoding to be configurable in pgsql? It could simply use `Json = application:get_env(pgsql, json_module)` to look up the name of the module the user wants to use, and assume it exports `encode/1` and `decode/1`.