### PR TITLE
Added a query option to return rows as maps.

### DIFF
--- a/src/pgsql_connection.erl
+++ b/src/pgsql_connection.erl
@@ -101,7 +101,7 @@
 -type pgsql_connection() :: {pgsql_connection, pid()}.
 
 -type n_rows() :: integer().
--type row() :: tuple().
+-type row() :: tuple() | map().
 -type rows() :: [row()].
 -type odbc_result_tuple() :: {updated, n_rows()} | {updated, n_rows(), rows()} | {selected, rows()}.
 % Column descriptions are returned with return_descriptions query option, an
@@ -144,6 +144,7 @@
         {max_rows_step, non_neg_integer()}      % default: ?DEFAULT_MAX_ROWS_STEP
     |   {retry, boolean()}                      % default: false
     |   {return_descriptions, boolean()}        % default: false
+    |   {return_maps, boolean()}                % default: false
     |   {datetime_float_seconds, round | always | as_available} % default: as_available
     |   proplists:property().                   % undocumented.
 -type query_options() :: [query_option()].

--- a/src/pgsql_protocol.erl
+++ b/src/pgsql_protocol.erl
@@ -767,9 +767,20 @@ decode_row(Descs, Values, OIDMap, DecodeOptions) ->
 
 decode_row0([Desc | DescsT], [Value | ValuesT], OIDMap, DecodeOptions, Acc) ->
     DecodedValue = decode_value(Desc, Value, OIDMap, DecodeOptions),
-    decode_row0(DescsT, ValuesT, OIDMap, DecodeOptions, [DecodedValue | Acc]);
-decode_row0([], [], _OIDMap, _DecodeOptions, Acc) ->
-    list_to_tuple(lists:reverse(Acc)).
+    case proplists:get_bool(return_maps, DecodeOptions) of
+        true ->
+            #row_description_field{name = FieldName} = Desc,
+            decode_row0(DescsT, ValuesT, OIDMap, DecodeOptions, [{FieldName, DecodedValue} | Acc]);
+        false ->
+            decode_row0(DescsT, ValuesT, OIDMap, DecodeOptions, [DecodedValue | Acc])
+    end;
+decode_row0([], [], _OIDMap, DecodeOptions, Acc) ->
+    case proplists:get_bool(return_maps, DecodeOptions) of
+        true ->
+            maps:from_list(Acc);
+        false ->
+            list_to_tuple(lists:reverse(Acc))
+    end.
 
 decode_value(_Desc, null, _OIDMap, _DecodeOptions) -> null;
 decode_value(#row_description_field{data_type_oid = TypeOID, format = text}, Value, OIDMap, DecodeOptions) ->

--- a/test/pgsql_connection_test.erl
+++ b/test/pgsql_connection_test.erl
@@ -1073,13 +1073,13 @@ return_maps_test_() ->
                     ?_test(
                         begin
                             R = pgsql_connection:simple_query("select 'foo'::text as a", [{return_maps, true}], Conn),
-                            ?assertMatch({{select,1}, [#{<<"a">> => <<"foo">>}]}, R)
+                            ?assertMatch({{select,1}, [#{<<"a">> := <<"foo">>}]}, R)
                         end
                     ),
                     ?_test(
                         begin
                             R = pgsql_connection:extended_query("select $1::text as a", [<<"foo">>], [{return_maps, true}], Conn),
-                            ?assertMatch({{select,1}, [#{<<"a">> => <<"foo">>}]}, R)
+                            ?assertMatch({{select,1}, [#{<<"a">> := <<"foo">>}]}, R)
                         end
                     )
                 ]


### PR DESCRIPTION
A small change to be able to return maps instead of tuples. 
This way it is pretty easy to work or encode to JSON the returned rows. 

It looks like `decode_row0/5` is the right place to do this and the query options make it very easy. I also updated the row type and the tests.

I haven't been able to run the tests on my laptop yet.