### PR TITLE
add json and jsonb support to protocol

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ before_install:
 matrix:
   include:
     - otp_release: 17.1
-      env: TRAVIS_POSTGRESQL_VERSION=9.1
-    - otp_release: 17.1
       env: TRAVIS_POSTGRESQL_VERSION=9.2
     - otp_release: 17.1
       env: TRAVIS_POSTGRESQL_VERSION=9.3
+    - otp_release: 17.1
+      env: TRAVIS_POSTGRESQL_VERSION=9.4

--- a/src/pgsql_internal.hrl
+++ b/src/pgsql_internal.hrl
@@ -1,9 +1,10 @@
-
 % Backend messages
 -type pgsql_oid() :: pos_integer().
 -type pgsql_procid() :: integer().
 -type pgsql_format() :: text | binary.
 -type pgsql_oid_map() :: gb_trees:tree(pgsql_oid(), atom()).
+
+-define(JSONB_VERSION_1, 1).
 
 % from pg_type.h
 -define(BOOLOID, 16).
@@ -22,6 +23,7 @@
 -define(CIDOID, 29).
 -define(OIDVECTOROID, 30).
 -define(JSONOID, 114).
+-define(JSONBOID, 3802).
 -define(XMLOID, 142).
 -define(PGNODETREEOID, 194).
 -define(POINTOID, 600).
@@ -132,6 +134,7 @@
 {?CIDOID, cid},
 {?OIDVECTOROID, oidvector},
 {?JSONOID, json},
+{?JSONBOID, jsonb},
 {?XMLOID, xml},
 {?PGNODETREEOID, pgnodetree},
 {?POINTOID, point},

--- a/src/pgsql_protocol.erl
+++ b/src/pgsql_protocol.erl
@@ -158,6 +158,12 @@ encode_parameter({array, List}, Type, OIDMap, IntegerDateTimes) ->
 encode_parameter(Binary, ?TEXTOID, _OIDMap, _IntegerDateTimes) when is_binary(Binary) ->
     Size = byte_size(Binary),
     {binary, <<Size:32/integer, Binary/binary>>};
+encode_parameter({json, Binary}, _Type, _OIDMap, _IntegerDateTimes) ->
+    Size = byte_size(Binary),
+    {binary, <<Size:32/integer, Binary/binary>>};
+encode_parameter({jsonb, Binary}, _Type, _OIDMap, _IntegerDateTimes) ->
+    Size = byte_size(Binary),
+    {binary, <<(Size+1):32/integer, ?JSONB_VERSION_1:8, Binary/binary>>};
 encode_parameter(Binary, _Type, _OIDMap, _IntegerDateTimes) when is_binary(Binary) ->
     % Encode the binary as text if it is a UUID.
     IsUUID = case Binary of
@@ -974,6 +980,7 @@ decode_array_text0(<<$\\, C, Rest/binary>>, true, Acc) ->
 decode_array_text0(<<C, Rest/binary>>, Quoted, Acc) ->
     decode_array_text0(Rest, Quoted, [C | Acc]).
 
+decode_value_bin(?JSONBOID, <<?JSONB_VERSION_1:8, Value/binary>>, _OIDMap, _IntegerDateTimes) -> Value;
 decode_value_bin(?BOOLOID, <<0>>, _OIDMap, _DecodeOptions) -> false;
 decode_value_bin(?BOOLOID, <<1>>, _OIDMap, _DecodeOptions) -> true;
 decode_value_bin(?BYTEAOID, Value, _OIDMap, _DecodeOptions) -> Value;


### PR DESCRIPTION
Opening in place of https://github.com/semiocast/pgsql/pull/35 -- github won't let me change the branch for the PR to be from and I needed to update the commits without breaking the lock file we use at work to use my fork :)

In my opinion it should just stay as it is right now and return the tuple `{json, binary()}` or `{jsonb, binary()}`.