### PR TITLE
Added a connection_timeout option and the related test case

### DIFF
--- a/src/pgsql_connection.erl
+++ b/src/pgsql_connection.erl
@@ -138,6 +138,7 @@
     |   {application_name, atom() | iodata()}   % default: node()
     |   {timezone, iodata() | undefined}        % default: undefined (not set)
     |   {async, pid()}                          % subscribe to notifications (default: no)
+    |   {connection_timeout, integer()}         % default: infinity
     |   proplists:property().                   % undocumented !
 -type open_options() :: [open_option()].
 -type query_option() ::
@@ -450,7 +451,12 @@ unsubscribe(Pid, {pgsql_connection, ConnectionPid}) ->
 %%
 -spec start_link(open_options()) -> {ok, pid()} | {error, any()}.
 start_link(Options) ->
-    gen_server:start_link(?MODULE, Options, []).
+  case lists:keytake(connection_timeout, 1, Options) of
+    false ->
+      gen_server:start_link(?MODULE, Options, []);
+    {value, {connection_timeout, Timeout}, ConnectionOptions} ->
+      gen_server:start_link(?MODULE, ConnectionOptions, [{timeout, Timeout}])
+  end.
 
 %% ========================================================================= %%
 %% gen_server API

--- a/test/pgsql_connection_test.erl
+++ b/test/pgsql_connection_test.erl
@@ -63,6 +63,16 @@ open_close_test_() ->
             catch throw:{pgsql_error, _Error} ->
                 ok
             end
+        end)},
+        {"Connection timeout",
+        ?_test(begin
+            try
+                R = pgsql_connection:open("0.0.0.0", "test", "test", "", [{connection_timeout, 0}]),
+                pgsql_connection:close(R),
+                ?assert(false)
+            catch throw:timeout ->
+                ok
+            end
         end)}
     ]}.
 


### PR DESCRIPTION
Related to https://github.com/semiocast/pgsql/issues/49.
I don't know if the lists:keytake/3 is necessary here might rewrite it with a lists:keyfind/3 instead.