### PR TITLE
Ability to open Postgres connections with URL

### DIFF
--- a/src/pgsql_connection.erl
+++ b/src/pgsql_connection.erl
@@ -126,7 +126,8 @@
 
 % driver options.
 -type open_option() ::
-        {host, inet:ip_address() | inet:hostname()} % default: ?DEFAULT_HOST
+        {url, iodata()} % default: none
+    |   {host, inet:ip_address() | inet:hostname()} % default: ?DEFAULT_HOST
     |   {port, integer()}                       % default: ?DEFAULT_PORT
     |   {database, iodata()}                    % default: user
     |   {user, iodata()}                        % default: ?DEFAULT_USER
@@ -198,6 +199,8 @@
 -spec open(iodata() | open_options()) -> pgsql_connection().
 open([Option | _OptionsT] = Options) when is_tuple(Option) orelse is_atom(Option) ->
     open0(Options);
+open(("postgres://" ++ _) = Url) ->
+    open([{url, Url}]);
 open(Database) ->
     open(Database, ?DEFAULT_USER).
 
@@ -234,7 +237,8 @@ open0(Options) ->
     case pgsql_connection_sup:start_child(Options) of
         {ok, Pid} ->
             {pgsql_connection, Pid};
-        {error, Error} -> throw(Error)
+        {error, Error} -> 
+            throw(Error)
     end.
 
 %%--------------------------------------------------------------------
@@ -245,6 +249,7 @@ close({pgsql_connection, Pid}) ->
     MonitorRef = erlang:monitor(process, Pid),
     exit(Pid, shutdown),
     receive {'DOWN', MonitorRef, process, Pid, _Info} -> ok end.
+
 
 %%--------------------------------------------------------------------
 %% @doc Perform a query.
@@ -568,10 +573,79 @@ terminate(_Reason, #state{socket = {SocketModule, Socket}}) ->
 %% Private functions
 %%====================================================================
 
+
+%% @doc splits string, but when unsplittable, assigns result 
+%%      to second part. First part is an empty string ("").
+split_to_second_part([OnlyOne]) ->
+    ["", OnlyOne];
+split_to_second_part([One, Two]) ->
+    [One, Two].
+
+%% @doc splits string, but when unsplittable, assigns result 
+%%      to second part. First part is an empty string ("").
+split_to_first_part([OnlyOne]) ->
+    [OnlyOne, ""];
+split_to_first_part([One, Two]) ->
+    [One, Two].
+
+%%--------------------------------------------------------------------
+%% @doc Parse a postgres connection URL into components
+%%
+%% Example: postgres://username:password@host:port/database
+parse_url("postgres://"++_RemainingUrl) -> 
+    [Credentials, HostPortDatabase] = split_to_second_part(string:split(_RemainingUrl, "@")),
+    [Username, Password] = split_to_first_part(string:split(Credentials, ":")),
+    [HostPort, Database] = split_to_first_part(string:split(HostPortDatabase, "/")),
+    [Host, Port] = split_to_first_part(string:split(HostPort, ":")),
+    ParsedOptionsEmpty = [],
+    ParsedOptionsWithUserName = case string:is_empty(Username) of
+            false -> ParsedOptionsEmpty ++ [{user, Username}];
+            true -> ParsedOptionsEmpty
+    end,
+    ParsedOptionsWithPassword = case string:is_empty(Password) of
+        false -> ParsedOptionsWithUserName ++ [{password, Password}];
+        true -> ParsedOptionsWithUserName
+    end,
+    ParsedOptionsWithHost = case string:is_empty(Host) of 
+        false  -> ParsedOptionsWithPassword ++ [{host, Host}];
+        true -> ParsedOptionsWithPassword
+    end,
+    ParsedOptionsWithPort = case string:is_empty(Port) of 
+        false -> [Portnum, _] = string:to_integer(Port),
+                ParsedOptionsWithHost ++ [{port, Portnum}];
+        true -> ParsedOptionsWithHost
+    end,
+    ParsedOptionsWithDatabase = case string:is_empty(Database) of 
+        false -> ParsedOptionsWithPort ++ [{database, Database}];
+        true -> ParsedOptionsWithPort
+    end,
+    ParsedOptionsWithDatabase.
+
 %%--------------------------------------------------------------------
 %% @doc Actually open (or re-open) the connection.
 %%
-pgsql_open(#state{options = Options} = State0) ->
+pgsql_open(#state{options = RawOptions} = RawState0) ->
+    Url = proplists:get_value(url, RawOptions, ""),
+    NotEmpty = not string:is_empty(Url),
+    Options = if NotEmpty ->
+            ParsedFromUrlOptions = parse_url(Url),
+            OriginalWithoutUrlOptions = proplists:delete(url, RawOptions),
+            UnifiedOptions = ParsedFromUrlOptions++OriginalWithoutUrlOptions,
+            UnifiedOptions;
+        true -> RawOptions
+    end,
+    State0=#state{
+        options = Options,
+        socket = RawState0#state.socket,
+        subscribers = RawState0#state.subscribers,
+        backend_procid = RawState0#state.backend_procid,
+        backend_secret = RawState0#state.backend_secret,
+        integer_datetimes = RawState0#state.integer_datetimes,
+        oidmap = RawState0#state.oidmap,
+        current = RawState0#state.current,
+        pending = RawState0#state.pending,
+        statement_timeout = RawState0#state.statement_timeout
+    },
     Host = proplists:get_value(host, Options, ?DEFAULT_HOST),
     Port = proplists:get_value(port, Options, ?DEFAULT_PORT),
     % First open a TCP connection

--- a/src/pgsql_connection_sup.erl
+++ b/src/pgsql_connection_sup.erl
@@ -41,4 +41,5 @@ init(_Args) ->
 %%
 -spec start_child([{atom(), string()}]) -> {ok, pid()} | {error, any()}.
 start_child(Options) ->
-    supervisor:start_child(?MODULE, [Options]).
+    Result = supervisor:start_child(?MODULE, [Options]),
+    Result.

--- a/test/pgsql_connection_test.erl
+++ b/test/pgsql_connection_test.erl
@@ -13,6 +13,81 @@ kill_sup(SupPid) ->
     receive {'EXIT', SupPid, _Reason} -> ok after 5000 -> throw({error, timeout}) end,
     process_flag(trap_exit, OldTrapExit).
 
+url_parse_test_() ->
+    {setup,
+    fun() ->
+        {ok, Pid} = pgsql_connection_sup:start_link(),
+        Pid
+    end,
+    fun(SupPid) ->
+        kill_sup(SupPid)
+    end,
+    [
+        {"Parse everything",
+        ?_test(begin
+            Options = pgsql_connection:parse_url("postgres://username:password@host1:3241/database3"),
+            User = proplists:get_value(user, Options),
+            Password = proplists:get_value(password, Options),
+            Host = proplists:get_value(host, Options),
+            Port = proplists:get_value(port, Options),
+            Database = proplists:get_value(database, Options),
+            ?assertEqual("username", User),
+            ?assertEqual("password", Password),
+            ?assertEqual("host1", Host),
+            ?assertEqual(3241, Port),
+            ?assertEqual("database3", Database)
+        end)},
+        {"Parse only username, no password",
+        ?_test(begin
+            Options = pgsql_connection:parse_url("postgres://:password@host1"),
+            Password = proplists:get_value(password, Options),
+            Host = proplists:get_value(host, Options),
+            ?assertEqual("password", Password),
+            ?assertEqual("host1", Host)
+        end)},
+        {"Parse only password, no username",
+        ?_test(begin
+            Options = pgsql_connection:parse_url("postgres://username@host1"),
+            User = proplists:get_value(user, Options),
+            Host = proplists:get_value(host, Options),
+            ?assertEqual("username", User),
+            ?assertEqual("host1", Host)
+        end)},
+        {"Parse only host and database",
+        ?_test(begin
+            Options = pgsql_connection:parse_url("postgres://host1/database3"),
+            Host = proplists:get_value(host, Options),
+            Database = proplists:get_value(database, Options),
+            ?assertEqual("host1", Host),
+            ?assertEqual("database3", Database)
+        end)},
+        {"Parse username, password, port and database (no host)",
+        ?_test(begin
+            Options = pgsql_connection:parse_url("postgres://username:password@:3241/database3"),
+            User = proplists:get_value(user, Options),
+            Password = proplists:get_value(password, Options),
+            Port = proplists:get_value(port, Options),
+            Database = proplists:get_value(database, Options),
+            ?assertEqual("username", User),
+            ?assertEqual("password", Password),
+            ?assertEqual(3241, Port),
+            ?assertEqual("database3", Database)
+        end)},
+        {"Parse only host",
+        ?_test(begin
+            Options = pgsql_connection:parse_url("postgres://host5"),
+            Host = proplists:get_value(host, Options),
+            ?assertEqual("host5", Host)
+        end)},
+        {"Parse host and port",
+        ?_test(begin
+            Options = pgsql_connection:parse_url("postgres://host5:4562"),
+            Host = proplists:get_value(host, Options),
+            Port = proplists:get_value(port, Options),
+            ?assertEqual("host5", Host),
+            ?assertEqual(4562, Port)
+        end)}
+    ]}.
 
 open_close_test_() ->
     {setup,

--- a/test/pgsql_connection_test.erl
+++ b/test/pgsql_connection_test.erl
@@ -54,6 +54,16 @@ open_close_test_() ->
             R = pgsql_connection:open([{host, "0.0.0.0"}, {database, "test"}, {user, "test"}, {password, ""}]),
             pgsql_connection:close(R)
         end)},
+        {"Open connection to test database with url as an option",
+        ?_test(begin
+            R = pgsql_connection:open([{url, "postgres://test:@0.0.0.0/test"}]),
+            pgsql_connection:close(R)
+        end)},
+        {"Open connection to test database with url as parameter",
+        ?_test(begin
+            R = pgsql_connection:open("postgres://test:@0.0.0.0/test"),
+            pgsql_connection:close(R)
+        end)},
         {"Bad user throws",
         ?_test(begin
             try
@@ -718,8 +728,8 @@ float_types_test_() ->
         ?_assertEqual({selected, [{1.0}]}, pgsql_connection:param_query("select 1.0::float4", [], Conn)),
         ?_assertEqual({selected, [{1.0}]}, pgsql_connection:param_query("select 1.0::float8", [], Conn)),
 
-        ?_assertEqual({selected, [{3.14159}]}, pgsql_connection:sql_query("select 3.141592653589793::float4", Conn)),
-        ?_assertEqual({selected, [{3.14159265358979}]}, pgsql_connection:sql_query("select 3.141592653589793::float8", Conn)),
+        ?_assertEqual({selected, [{3.1415927}]}, pgsql_connection:sql_query("select 3.141592653589793::float4", Conn)),
+        ?_assertEqual({selected, [{3.141592653589793}]}, pgsql_connection:sql_query("select 3.141592653589793::float8", Conn)),
         ?_assertEqual({selected, [{3.1415927410125732}]}, pgsql_connection:param_query("select 3.141592653589793::float4", [], Conn)),
         ?_assertEqual({selected, [{3.141592653589793}]}, pgsql_connection:param_query("select 3.141592653589793::float8", [], Conn)),
 


### PR DESCRIPTION
This change enables, as captured in unit tests, the ability to open connections using a Postgres URL. This is crucial for Heroku-like scenarios that expose a single environment variable of the URL.

Two supported formats are as follows.

1. Single URL as parameter
```
            R = pgsql_connection:open("postgres://test:@0.0.0.0/test"),
            pgsql_connection:close(R)
```

2. URL as an option:
```
            R = pgsql_connection:open([{url, "postgres://test:@0.0.0.0/test"}]),
            pgsql_connection:close(R)
```

Both have a Unit Test.